### PR TITLE
Fix module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
     }
   ],
    "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.2.4" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Like I said in https://github.com/amoswood/puppet-neo4j/issues/7, the puppetlabs-concat module dependency is missing making the module fail.
